### PR TITLE
Add pagination

### DIFF
--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -54,35 +54,3 @@ class farmOS:
                 return data['list']
 
         return []
-
-
-    def page_count(self, entity_type, filters={}):
-        """
-        Determines how many pages of records are available for
-        a given entity type and filter(s).
-        """
-        pages = 0
-
-        data = self.get_record_data(entity_type, filters)
-
-        # If the 'last' page is not set, return 0
-        if ('last' not in data):
-            return pages
-
-        # The number of pages is the last page + 1
-        parsed_url = urlparse(data['last'])
-        pages = parse_qs(parsed_url.query)['page'][0]
-        return int(pages) + 1
-
-    def _get_record_data(self, entity_type, filters={}):
-        """Retrieve raw record data from the farmOS API."""
-        path = entity_type + '.json'
-
-        if filters and 'id' in filters:
-            path = entity_type + '/' + filters['id'] + '.json'
-
-        response = self.session.http_request(path=path, params=filters)
-        if (response.status_code == 200):
-            return response.json()
-
-        return []

--- a/tests/functional/test_log.py
+++ b/tests/functional/test_log.py
@@ -24,10 +24,16 @@ def test_create_log(test_farm):
     created_log = test_farm.log.get(response['id'])
     assert created_log['timestamp'] == test_log['timestamp']
 
-def test_get_all_logs(test_farm):
-    logs = test_farm.log.get()
+def test_get_one_page_of_logs(test_farm):
+    logs = test_farm.log.get({'page':0})
 
     assert len(logs) > 0
+
+def test_get_all_logs(test_farm):
+    one_page_logs = test_farm.log.get({'page':0})
+    all_logs = test_farm.log.get()
+
+    assert len(all_logs) > len(one_page_logs)
 
 def test_get_logs_filtered_by_type(test_farm):
     log_type = test_log['type']


### PR DESCRIPTION
Add pagination to the client.  Fixes #8 
Add a simple pagination test for logs.

Design the client.py code to we only need to override the simple .get() method for the endpoint API Classes (when needed)


