### PR TITLE
Add OAuth support

### DIFF
--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from urllib.parse import urlparse
 
 from .session import DrupalAuthSession, OAuthSession
 from .client import LogAPI, AssetAPI, TermAPI, AreaAPI
@@ -68,11 +69,21 @@ class farmOS:
             if username is None and client_id is None:
                 raise Exception("No authentication method provided.")
 
-        # TODO: validate the hostname
-        #   validate the url with urllib.parse
         if hostname is not None:
-            # Save the hostname in the authentication configuration.
-            self.config.set(self.profile_name, "hostname", hostname)
+            valid_schemes = ["http", "https"]
+            o = urlparse(hostname)
+
+            # Validate the hostname.
+            if not o.scheme and not o.netloc:
+                raise Exception("Invalid hostname. Must have scheme and netloc.")
+            elif o.scheme not in valid_schemes:
+                raise Exception("Not a valid scheme.")
+            elif o.path or o.params or o.query:
+                raise Exception("Hostname cannot include path and query parameters.")
+            else:
+                # Save the hostname in the authentication configuration.
+                self.config.set(self.profile_name, "hostname", hostname)
+
         else:
             raise Exception("No hostname provided in config file.")
 

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -76,6 +76,8 @@ class farmOS:
         self.area = AreaAPI(self.session)
         self.term = TermAPI(self.session)
 
+        if self.config.getboolean("client", "auto_authenticate"):
+            self.session.authenticate()
 
     def authenticate(self):
         """Authenticates with the farmOS site.

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -34,8 +34,8 @@ class farmOS:
 
         # If a client_id is supplied, try to create an OAuth Session
         if client_id is not None:
-            self.session = OAuthSession(client_id, client_secret=client_secret,
-                                        hostname=hostname, redirect_uri="http://localhost/api/authorized")
+            self.session = OAuthSession(hostname=hostname, client_id=client_id, client_secret=client_secret,
+                                        redirect_uri="http://localhost/api/authorized", token_url="http://localhost/oauth2/token")
 
         # Fallback to DrupalAPISession
         if username is not None and password is not None:

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -19,7 +19,7 @@ class farmOS:
     """
 
     def __init__(self, hostname=None, username=None, password=None, client_id=None, client_secret=None, config_file=None,
-                 profile_name=None):
+                 profile_name=None, token_updater=None):
         # Start a list of config files.
         config_file_list = ['farmos_default_config.cfg']
 
@@ -81,6 +81,10 @@ class farmOS:
             from getpass import getpass
             password = getpass('Enter password: ')
 
+        # Default to simple token_saver to save tokens to config.
+        if token_updater is None:
+            token_updater = self.save_token
+
         # If a client_id is supplied, try to create an OAuth Session
         if client_id is not None:
             token_url = self.config.get(self.profile_name, "oauth_token_url")
@@ -124,7 +128,7 @@ class farmOS:
             # Create an OAuth Session
             self.session = OAuthSession(hostname=hostname, client_id=client_id, client_secret=client_secret,
                                         token=token, redirect_uri=redirect_url, token_url=token_url,
-                                        authorization_url=authorization_url, token_updater=self.save_token)
+                                        authorization_url=authorization_url, token_updater=token_updater)
 
         # Fallback to DrupalAPISession
         if username is not None and password is not None:

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from .session import DrupalAuthSession, OAuthSession
 from .client import LogAPI, AssetAPI, TermAPI, AreaAPI
 from .config import ClientConfig
@@ -77,6 +79,25 @@ class farmOS:
                 # If an access_token is not saved, do not use the token dict.
                 if 'access_token' not in token:
                     token = None
+
+                # Unset the expires_in key.
+                token.pop('expires_in')
+
+                # Check the token expiration time.
+                if 'expires_at' in token:
+                    # Create datetime objects for comparison.
+                    now = datetime.now()
+                    expiration_time = datetime.fromtimestamp(float(token['expires_at']))
+
+                    # Calculate seconds until expiration.
+                    timedelta = expiration_time - now
+                    expires_in = timedelta.total_seconds()
+
+                    # Update the token expires_in value
+                    token['expires_in'] = expires_in
+
+                # Unset the expires_at key.
+                token.pop('expires_at')
 
             # Load saved OAuth URLs from config.
             authorization_url = self.config.get("OAuth", "oauth_authorization_url")

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -34,6 +34,16 @@ class farmOS:
         # Read config files.
         self.config.read(config_file_list)
 
+        # Load the config boolean for development mode.
+        self.development = self.config.getboolean("client", "development", fallback=False)
+
+        # Allow authentication over HTTP in development mode
+        # or if the oauth_insecure_transport config is enabled.
+        oauth_insecure_transport = self.config.getboolean("oauth", "oauthlib_insecure_transport", fallback=False)
+        if self.development or oauth_insecure_transport:
+            import os
+            os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
+
         self.session = None
 
         # TODO: validate the hostname

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -104,17 +104,3 @@ class farmOS:
             return response.json()
 
         return []
-
-    def vocabulary(self, machine_name=None):
-        path='taxonomy_vocabulary.json'
-        params = {}
-        params['machine_name'] = machine_name
-
-        response = self.session.http_request(path=path, params=params)
-
-        if (response.status_code == 200):
-            data = response.json()
-            if 'list' in data:
-                return data['list']
-
-        return []

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -17,8 +17,38 @@ class farmOS:
 
     """
 
-    def __init__(self, hostname, username, password):
-        self.session = APISession(hostname, username, password)
+    def __init__(self, hostname, username=None, password=None, client_id=None, client_secret=None):
+        self.session = None
+
+        # TODO: validate the hostname
+        #   validate the url with urllib.parse
+
+        # A username or client_id is required for authentication to farmOS.
+        if username is None and client_id is None:
+            raise Exception("No authentication method provided.")
+
+        # Ask for password if username is given without a password.
+        if username is not None and password is None:
+            from getpass import getpass
+            password = getpass('Enter password: ')
+
+        # TODO: create OAuth Session
+        # If a client_id is supplied, try to create an OAuth Session
+        # if client_id is not None:
+
+        # Fallback to DrupalAPISession
+        if username is not None and password is not None:
+            # Create a session with requests
+            self.session = DrupalAuthSession(hostname, username, password)
+
+        self._username = username
+        self._client_id = client_id
+        self._client_secret = client_secret
+
+        if self.session is None:
+            raise Exception("Could not create a session object. Supply authentication credentials when "\
+                            "initializing a farmOS Client.")
+
         self.log = LogAPI(self.session)
         self.asset = AssetAPI(self.session)
         self.area = AreaAPI(self.session)

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -148,7 +148,11 @@ class farmOS:
         self.area = AreaAPI(self.session)
         self.term = TermAPI(self.session)
 
-        if self.config.getboolean(self.profile_name, "auto_authenticate", fallback=True):
+        # Authenticate the session if auto_authenticate is enabled
+        # and the session has not already been authenticated.
+        # (OAuthSession will authenticate if an existing token was provided at startup)
+        auto_authenticate = self.config.getboolean(self.profile_name, "auto_authenticate", fallback=True)
+        if auto_authenticate and not self.session.is_authenticated():
             self.session.authenticate()
 
     def authenticate(self):

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -38,6 +38,8 @@ class farmOS:
 
         # TODO: validate the hostname
         #   validate the url with urllib.parse
+        # Save the hostname in the authentication configuration.
+        self.config.set("authentication", "hostname", hostname)
 
         # A username or client_id is required for authentication to farmOS.
         if username is None and client_id is None:
@@ -50,10 +52,11 @@ class farmOS:
 
         # If a client_id is supplied, try to create an OAuth Session
         if client_id is not None:
-            redirect_uri = self.config.get("oauth", "oauth_redirect_uri")
+            redirect_url = self.config.get("oauth", "oauth_redirect_url")
             token_url = self.config.get("oauth", "oauth_token_url")
+            authorization_url = self.config.get("oauth", "oauth_authorization_url")
             self.session = OAuthSession(hostname=hostname, client_id=client_id, client_secret=client_secret,
-                                        redirect_uri=redirect_uri, token_url=token_url)
+                                        redirect_uri=redirect_url, token_url=token_url, authorization_url=authorization_url)
 
         # Fallback to DrupalAPISession
         if username is not None and password is not None:

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -156,10 +156,8 @@ class farmOS:
                 # requests-oauthlib module does not save this value as a string. Bug?
                 self.config.set(profile_name, "expires_at", str(token['expires_at']))
 
-        # TODO: Save the first token values retrieved from
-        #  a successful OAuth Authorization Code Grant
-
-        # TODO: rewrite the token values to config on every change.
+        if self.config_file is not None:
+            self.config.write(path=self.config_file)
 
     def create_profile(self, profile_name):
         """Creates a Section for profile_name in farm.config."""

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -1,7 +1,6 @@
-from urllib.parse import urlparse, parse_qs
-
 from .session import DrupalAuthSession, OAuthSession
 from .client import LogAPI, AssetAPI, TermAPI, AreaAPI
+from .config import ClientConfig
 
 class farmOS:
 
@@ -17,7 +16,24 @@ class farmOS:
 
     """
 
-    def __init__(self, hostname, username=None, password=None, client_id=None, client_secret=None):
+    def __init__(self, hostname, username=None, password=None, client_id=None, client_secret=None, config_files=None):
+        # Start a list of config files.
+        config_file_list = ['farmos_default_config.cfg']
+
+        # Append additional config files.
+        if config_files is not None:
+            if isinstance(config_files, list):
+                config_file_list.extend(config_files)
+            elif isinstance(config_files, str):
+                config_file_list.append(config_files)
+            else:
+                print("config_files must be List or String.")
+
+        # Create a ClientConfig object.
+        self.config = ClientConfig()
+        # Read config files.
+        self.config.read(config_file_list)
+
         self.session = None
 
         # TODO: validate the hostname
@@ -34,8 +50,10 @@ class farmOS:
 
         # If a client_id is supplied, try to create an OAuth Session
         if client_id is not None:
+            redirect_uri = self.config.get("oauth", "oauth_redirect_uri")
+            token_url = self.config.get("oauth", "oauth_token_url")
             self.session = OAuthSession(hostname=hostname, client_id=client_id, client_secret=client_secret,
-                                        redirect_uri="http://localhost/api/authorized", token_url="http://localhost/oauth2/token")
+                                        redirect_uri=redirect_uri, token_url=token_url)
 
         # Fallback to DrupalAPISession
         if username is not None and password is not None:

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlparse, parse_qs
 
-from .session import APISession
+from .session import DrupalAuthSession
 from .client import LogAPI, AssetAPI, TermAPI, AreaAPI
 
 class farmOS:

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -35,11 +35,11 @@ class farmOS:
         self.config.read(config_file_list)
 
         # Load the config boolean for development mode.
-        self.development = self.config.getboolean("client", "development", fallback=False)
+        self.development = self.config.getboolean("Client", "development", fallback=False)
 
         # Allow authentication over HTTP in development mode
         # or if the oauth_insecure_transport config is enabled.
-        oauth_insecure_transport = self.config.getboolean("oauth", "oauthlib_insecure_transport", fallback=False)
+        oauth_insecure_transport = self.config.getboolean("OAuth", "oauthlib_insecure_transport", fallback=False)
         if self.development or oauth_insecure_transport:
             import os
             os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
@@ -49,7 +49,7 @@ class farmOS:
         # TODO: validate the hostname
         #   validate the url with urllib.parse
         # Save the hostname in the authentication configuration.
-        self.config.set("authentication", "hostname", hostname)
+        self.config.set("Authentication", "hostname", hostname)
 
         # A username or client_id is required for authentication to farmOS.
         if username is None and client_id is None:
@@ -62,9 +62,9 @@ class farmOS:
 
         # If a client_id is supplied, try to create an OAuth Session
         if client_id is not None:
-            redirect_url = self.config.get("oauth", "oauth_redirect_url")
-            token_url = self.config.get("oauth", "oauth_token_url")
-            authorization_url = self.config.get("oauth", "oauth_authorization_url")
+            redirect_url = self.config.get("OAuth", "oauth_redirect_url")
+            token_url = self.config.get("OAuth", "oauth_token_url")
+            authorization_url = self.config.get("OAuth", "oauth_authorization_url")
             self.session = OAuthSession(hostname=hostname, client_id=client_id, client_secret=client_secret,
                                         redirect_uri=redirect_url, token_url=token_url, authorization_url=authorization_url)
 
@@ -86,7 +86,7 @@ class farmOS:
         self.area = AreaAPI(self.session)
         self.term = TermAPI(self.session)
 
-        if self.config.getboolean("client", "auto_authenticate"):
+        if self.config.getboolean("Client", "auto_authenticate"):
             self.session.authenticate()
 
     def authenticate(self):

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -132,17 +132,39 @@ class farmOS:
                 # Unset the expires_at key.
                 token.pop('expires_at', None)
 
-            # Load saved OAuth URLs from config.
-            authorization_url = self.config.get(self.profile_name, "oauth_authorization_url")
-            redirect_url = self.config.get(self.profile_name, "oauth_redirect_url")
+            # Create an OAuth Session with the Password Credentials Grant.
+            if username is not None and password is not None:
+                self.config.set(self.profile_name, "username", username)
+                self.config.set(self.profile_name, "password", password)
+                self.session = OAuthSession(grant_type="Password",
+                                            hostname=hostname,
+                                            client_id=client_id,
+                                            client_secret=client_secret,
+                                            username=username,
+                                            password=password,
+                                            token=token,
+                                            token_url=token_url,
+                                            token_updater=token_updater)
 
-            # Create an OAuth Session
-            self.session = OAuthSession(hostname=hostname, client_id=client_id, client_secret=client_secret,
-                                        token=token, redirect_uri=redirect_url, token_url=token_url,
-                                        authorization_url=authorization_url, token_updater=token_updater)
+            # Create an OAuth Session with the Authorization Code Grant.
+            else:
+                # Load saved OAuth URLs from config.
+                authorization_url = self.config.get(self.profile_name, "oauth_authorization_url")
+                redirect_url = self.config.get(self.profile_name, "oauth_redirect_url")
+
+                # Create an OAuth Session
+                self.session = OAuthSession(grant_type="Authorization",
+                                            hostname=hostname,
+                                            client_id=client_id,
+                                            client_secret=client_secret,
+                                            token=token,
+                                            redirect_uri=redirect_url,
+                                            token_url=token_url,
+                                            authorization_url=authorization_url,
+                                            token_updater=token_updater)
 
         # Fallback to DrupalAPISession
-        if username is not None and password is not None:
+        if client_id is None and username is not None and password is not None:
             # Create a session with requests
             self.session = DrupalAuthSession(hostname, username, password)
 

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -62,9 +62,19 @@ class farmOS:
 
         # If a client_id is supplied, try to create an OAuth Session
         if client_id is not None:
-            redirect_url = self.config.get("OAuth", "oauth_redirect_url")
             token_url = self.config.get("OAuth", "oauth_token_url")
+
+            # Load saved Authentication values from config.
+            token = dict(self.config.items("Authentication"))
+            # If an access_token is not saved, do not use the token dict.
+            if 'access_token' not in token:
+                token = None
+
+            # Load saved OAuth URLs from config.
             authorization_url = self.config.get("OAuth", "oauth_authorization_url")
+            redirect_url = self.config.get("OAuth", "oauth_redirect_url")
+
+            # Create an OAuth Session
             self.session = OAuthSession(hostname=hostname, client_id=client_id, client_secret=client_secret,
                                         token=token, redirect_uri=redirect_url, token_url=token_url,
                                         authorization_url=authorization_url, token_updater=self.save_token)

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -16,18 +16,17 @@ class farmOS:
 
     """
 
-    def __init__(self, hostname, username=None, password=None, client_id=None, client_secret=None, config_files=None):
+    def __init__(self, hostname, username=None, password=None, client_id=None, client_secret=None, config_file=None):
         # Start a list of config files.
         config_file_list = ['farmos_default_config.cfg']
 
         # Append additional config files.
-        if config_files is not None:
-            if isinstance(config_files, list):
-                config_file_list.extend(config_files)
-            elif isinstance(config_files, str):
-                config_file_list.append(config_files)
+        if config_file is not None:
+            if isinstance(config_file, str):
+                config_file_list.append(config_file)
+                self.config_file = config_file
             else:
-                print("config_files must be List or String.")
+                raise Exception("Config file must be a string.")
 
         # Create a ClientConfig object.
         self.config = ClientConfig()

--- a/farmOS/__init__.py
+++ b/farmOS/__init__.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlparse, parse_qs
 
-from .session import DrupalAuthSession
+from .session import DrupalAuthSession, OAuthSession
 from .client import LogAPI, AssetAPI, TermAPI, AreaAPI
 
 class farmOS:
@@ -32,9 +32,10 @@ class farmOS:
             from getpass import getpass
             password = getpass('Enter password: ')
 
-        # TODO: create OAuth Session
         # If a client_id is supplied, try to create an OAuth Session
-        # if client_id is not None:
+        if client_id is not None:
+            self.session = OAuthSession(client_id, client_secret=client_secret,
+                                        hostname=hostname, redirect_uri="http://localhost/api/authorized")
 
         # Fallback to DrupalAPISession
         if username is not None and password is not None:

--- a/farmOS/client.py
+++ b/farmOS/client.py
@@ -1,7 +1,5 @@
 from urllib.parse import urlparse, parse_qs
 
-from .session import APISession
-
 class BaseAPI(object):
     """Base class for API methods
 

--- a/farmOS/config.py
+++ b/farmOS/config.py
@@ -9,7 +9,7 @@ class ClientConfig(ConfigParser):
         self.set("Client", "development", 'False')
 
         self.add_section("Authentication")
-        self.set("Authentication", "hostname", "http://localhost")
+        self.set("Authentication", "hostname", "")
 
         self.add_section("OAuth")
         self.set("OAuth", "oauth_authorization_url", "${Authentication:hostname}/oauth2/authorize")

--- a/farmOS/config.py
+++ b/farmOS/config.py
@@ -1,17 +1,20 @@
-from configparser import ConfigParser, NoSectionError
+from configparser import ConfigParser, ExtendedInterpolation
 
 class ClientConfig(ConfigParser):
     def __init__(self):
-        super(ClientConfig, self).__init__()
+        super(ClientConfig, self).__init__(interpolation=ExtendedInterpolation())
 
         self.add_section("client")
         self.set("client", "auto_authenticate", 'True')
         self.set("client", "development", 'False')
 
+        self.add_section("authentication")
+        self.set("authentication", "hostname", "http://localhost")
+
         self.add_section("oauth")
-        self.set("oauth", "oauth_authorization_url", "/oauth2/authorize")
-        self.set("oauth", "oauth_redirect_url", "/api/authorized")
-        self.set("oauth", "oauth_token_url", "/oauth2/token")
+        self.set("oauth", "oauth_authorization_url", "${authentication:hostname}/oauth2/authorize")
+        self.set("oauth", "oauth_redirect_url", "${authentication:hostname}/api/authorized")
+        self.set("oauth", "oauth_token_url", "${authentication:hostname}/oauth2/token")
         self.set("oauth", "oauthlib_insecure_transport", '0')
 
     def write(self, path="farmos_default_config.cfg"):

--- a/farmOS/config.py
+++ b/farmOS/config.py
@@ -1,0 +1,19 @@
+from configparser import ConfigParser, NoSectionError
+
+class ClientConfig(ConfigParser):
+    def __init__(self):
+        super(ClientConfig, self).__init__()
+
+        self.add_section("client")
+        self.set("client", "auto_authenticate", 'True')
+        self.set("client", "development", 'False')
+
+        self.add_section("oauth")
+        self.set("oauth", "oauth_authorization_url", "/oauth2/authorize")
+        self.set("oauth", "oauth_redirect_url", "/api/authorized")
+        self.set("oauth", "oauth_token_url", "/oauth2/token")
+        self.set("oauth", "oauthlib_insecure_transport", '0')
+
+    def write(self, path="farmos_default_config.cfg"):
+        with open(path, "w") as config_file:
+            super(ClientConfig, self).write(config_file)

--- a/farmOS/config.py
+++ b/farmOS/config.py
@@ -4,18 +4,18 @@ class ClientConfig(ConfigParser):
     def __init__(self):
         super(ClientConfig, self).__init__(interpolation=ExtendedInterpolation())
 
-        self.add_section("client")
-        self.set("client", "auto_authenticate", 'True')
-        self.set("client", "development", 'False')
+        self.add_section("Client")
+        self.set("Client", "auto_authenticate", 'True')
+        self.set("Client", "development", 'False')
 
-        self.add_section("authentication")
-        self.set("authentication", "hostname", "http://localhost")
+        self.add_section("Authentication")
+        self.set("Authentication", "hostname", "http://localhost")
 
-        self.add_section("oauth")
-        self.set("oauth", "oauth_authorization_url", "${authentication:hostname}/oauth2/authorize")
-        self.set("oauth", "oauth_redirect_url", "${authentication:hostname}/api/authorized")
-        self.set("oauth", "oauth_token_url", "${authentication:hostname}/oauth2/token")
-        self.set("oauth", "oauthlib_insecure_transport", 'False')
+        self.add_section("OAuth")
+        self.set("OAuth", "oauth_authorization_url", "${Authentication:hostname}/oauth2/authorize")
+        self.set("OAuth", "oauth_redirect_url", "${Authentication:hostname}/api/authorized")
+        self.set("OAuth", "oauth_token_url", "${Authentication:hostname}/oauth2/token")
+        self.set("OAuth", "oauthlib_insecure_transport", 'False')
 
     def write(self, path="farmos_default_config.cfg"):
         with open(path, "w") as config_file:

--- a/farmOS/config.py
+++ b/farmOS/config.py
@@ -1,21 +1,17 @@
-from configparser import ConfigParser, ExtendedInterpolation
+from configparser import ConfigParser, BasicInterpolation
 
 class ClientConfig(ConfigParser):
     def __init__(self):
-        super(ClientConfig, self).__init__(interpolation=ExtendedInterpolation())
+        defaults = {
+            'auto_authenticate': True,
+            'development': False,
+            'oauthlib_insecure_transport': False,
+            'oauth_authorization_url': '%(hostname)s/oauth2/authorize',
+            'oauth_redirect_url': '%(hostname)s/api/authorized',
+            'oauth_token_url': '%(hostname)s/oauth2/token',
+        }
 
-        self.add_section("Client")
-        self.set("Client", "auto_authenticate", 'True')
-        self.set("Client", "development", 'False')
-
-        self.add_section("Authentication")
-        self.set("Authentication", "hostname", "")
-
-        self.add_section("OAuth")
-        self.set("OAuth", "oauth_authorization_url", "${Authentication:hostname}/oauth2/authorize")
-        self.set("OAuth", "oauth_redirect_url", "${Authentication:hostname}/api/authorized")
-        self.set("OAuth", "oauth_token_url", "${Authentication:hostname}/oauth2/token")
-        self.set("OAuth", "oauthlib_insecure_transport", 'False')
+        super(ClientConfig, self).__init__(defaults=defaults, interpolation=BasicInterpolation())
 
     def write(self, path="farmos_default_config.cfg"):
         with open(path, "w") as config_file:

--- a/farmOS/config.py
+++ b/farmOS/config.py
@@ -15,7 +15,7 @@ class ClientConfig(ConfigParser):
         self.set("oauth", "oauth_authorization_url", "${authentication:hostname}/oauth2/authorize")
         self.set("oauth", "oauth_redirect_url", "${authentication:hostname}/api/authorized")
         self.set("oauth", "oauth_token_url", "${authentication:hostname}/oauth2/token")
-        self.set("oauth", "oauthlib_insecure_transport", '0')
+        self.set("oauth", "oauthlib_insecure_transport", 'False')
 
     def write(self, path="farmos_default_config.cfg"):
         with open(path, "w") as config_file:

--- a/farmOS/session.py
+++ b/farmOS/session.py
@@ -28,21 +28,28 @@ class OAuthSession(OAuth2Session):
         auto_refresh_kwargs = {'client_id': client_id,
                                'client_secret': client_secret
                                }
-        super(OAuthSession, self).__init__(client_id=client_id,
+        super(OAuthSession, self).__init__(token=token,
+                                           client_id=client_id,
                                            redirect_uri=redirect_uri,
                                            auto_refresh_url=token_url,
                                            auto_refresh_kwargs=auto_refresh_kwargs,
                                            token_updater=token_updater)
 
+        # Save values for later use.
         self._token_url = token_url
         self._authorization_base_url = authorization_url
         self._client_id = client_id
         self._client_secret = client_secret
         self._username = username
         self._password = password
-
-        self.authenticated = False
         self.hostname = hostname
+
+        # Check if an existing token was provided.
+        if token is not None and 'access_token' in token:
+            # TODO: Use a helper function to check if the client is authenticated.
+            self.authenticated = True
+        else:
+            self.authenticated = False
 
     def authenticate(self):
         """Authenticates with the farmOS site.

--- a/farmOS/session.py
+++ b/farmOS/session.py
@@ -22,7 +22,7 @@ class OAuthSession(OAuth2Session):
     """
 
     def __init__(self, hostname, client_id, client_secret=None, username=None, password=None,
-                 redirect_uri=None, token_url=None, token_updater = None, *args, **kwargs):
+                 redirect_uri=None, token_url=None, authorization_url=None, token_updater = None, *args, **kwargs):
         # Provide a default token_saver is nothing is provided.
         if token_updater is None:
             token_updater = self._token_saver
@@ -38,10 +38,10 @@ class OAuthSession(OAuth2Session):
                                            auto_refresh_kwargs=auto_refresh_kwargs,
                                            token_updater=token_updater)
 
+        self._token_url = token_url
+        self._authorization_base_url = authorization_url
         self._client_id = client_id
         self._client_secret = client_secret
-        self._authorization_base_url = hostname + '/oauth2/authorize'
-        self._redirect_uri = redirect_uri
         self._username = username
         self._password = password
 
@@ -64,8 +64,7 @@ class OAuthSession(OAuth2Session):
         redirect_response = input('Paste the full redirect URL here:')
 
         # Fetch the access token
-        token_url = self.hostname + '/oauth2/token'
-        self.fetch_token(token_url, client_secret=self._client_secret, authorization_response=redirect_response)
+        self.fetch_token(self._token_url, client_secret=self._client_secret, authorization_response=redirect_response)
 
         self.authenticated = True
 

--- a/farmOS/session.py
+++ b/farmOS/session.py
@@ -20,8 +20,10 @@ class OAuthSession(OAuth2Session):
     def __init__(self, hostname, client_id, client_secret=None, username=None, password=None, token=None,
                  redirect_uri=None, token_url=None, authorization_url=None, token_updater = None, *args, **kwargs):
         # Provide a default token_saver is nothing is provided.
-        if token_updater is None:
-            token_updater = self._token_saver
+        self.token_updater = self._token_saver
+        # Save a provided token updater.
+        if token_updater is not None:
+            self.token_updater = token_updater
 
         # Create a dictionary of credentials required to pass along with Refresh Tokens
         # Required to generate a new access token
@@ -33,7 +35,7 @@ class OAuthSession(OAuth2Session):
                                            redirect_uri=redirect_uri,
                                            auto_refresh_url=token_url,
                                            auto_refresh_kwargs=auto_refresh_kwargs,
-                                           token_updater=token_updater)
+                                           token_updater=self.token_updater)
 
         # Save values for later use.
         self._token_url = token_url
@@ -67,7 +69,10 @@ class OAuthSession(OAuth2Session):
         redirect_response = input('Paste the full redirect URL here:')
 
         # Fetch the access token
-        self.fetch_token(self._token_url, client_secret=self._client_secret, authorization_response=redirect_response)
+        token = self.fetch_token(self._token_url, client_secret=self._client_secret, authorization_response=redirect_response)
+
+        # Save the token.
+        self.token_updater(token)
 
         self.authenticated = True
 

--- a/farmOS/session.py
+++ b/farmOS/session.py
@@ -3,10 +3,6 @@ from requests_oauthlib import OAuth2Session
 
 from .exceptions import NotAuthenticatedError
 
-# Allow authentication over HTTP
-import os
-os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
-
 class OAuthSession(OAuth2Session):
     """OAuthSession uses OAuth2 to authenticate with farmOS
 

--- a/farmOS/session.py
+++ b/farmOS/session.py
@@ -17,7 +17,7 @@ class OAuthSession(OAuth2Session):
         password - the farmOS user's password (for OAuth2 Password Grant)
     """
 
-    def __init__(self, hostname, client_id, client_secret=None, username=None, password=None,
+    def __init__(self, hostname, client_id, client_secret=None, username=None, password=None, token=None,
                  redirect_uri=None, token_url=None, authorization_url=None, token_updater = None, *args, **kwargs):
         # Provide a default token_saver is nothing is provided.
         if token_updater is None:

--- a/farmOS/session.py
+++ b/farmOS/session.py
@@ -1,15 +1,16 @@
-import requests
+from requests import Session
 
 from .exceptions import NotAuthenticatedError
 
 # Use a Requests Session to store cookies across requests.
 #   http://docs.python-requests.org/en/master/user/advanced/#session-objects
-class APISession(requests.Session):
+class DrupalAuthSession(Session):
 
     """APISession handles all HTTP requests for the farmOS API
 
-    This class stores cookies and tokens generated from authentication
-    across all requests made to the farmOS host.
+    This class stores cookies and tokens required for the Drupal
+    RESTFul Web Services HTTP Session Authentication method.
+    These values are use in all requests made to the farmOS host.
 
     Keyword Arguments:
     hostname - the farmOS hostname (without protocol)
@@ -18,7 +19,7 @@ class APISession(requests.Session):
     """
 
     def __init__(self, hostname, username, password, *args, **kwargs):
-        super(APISession, self).__init__(*args, **kwargs)
+        super(DrupalAuthSession, self).__init__(*args, **kwargs)
 
         # Store farmOS authentication credentials
         self.hostname = hostname

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup_requires=[
 
 install_requires=[
     'requests',
+    'requests-oauthlib',
     ]
 
 tests_require=[


### PR DESCRIPTION
This PR adds the following:

- Structure the library to support multiple types of authentication
- Use configparser and config files to configure the client
- Add support the OAuth Authorization Flow
- Add support the OAuth Password Credentials Flow
- Auto-refresh Authentication Tokens by default
- Allow external methods to save tokens
- Save Authentication to a Profile in config file

This should be the majority of what is needed for a full OAuth implementation. A few things like writing tests for the OAuth integration remain, but I'm hesitant to do that before we have OAuth fully added to farmOS core.

With these additions I'll make a minor release so we can start further testing the library. I'm anxious to get working with farmOS Aggregator :grin: 