### PR TITLE
Add configuration for GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,16 @@
+image: python:latest
+
+# Change pip's cache directory to be inside the project directory since we can
+# only cache local items.
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+
+before_script:
+  - python -V  # Print out python version for debugging
+  - pip install virtualenv
+  - virtualenv venv
+  - source venv/bin/activate
+
+test:
+  script:
+    - python setup.py test


### PR DESCRIPTION
Add .gitlab-ci.yml file that only runs tests via `python setup.py test`

The GitLab Pipeline is configured with the required Environment variables to run tests against a farmOS testing server.