### PR TITLE
setup.py: python_requires=">=3.6"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3",
+    python_requires=">=3.6",
     setup_requires=setup_requires,
     install_requires=install_requires,
     tests_require=tests_require,


### PR DESCRIPTION
Corresponds to https://devguide.python.org/#branchstatus
and https://devguide.python.org/devcycle/#end-of-life-branches