### PR TITLE
Change docs source_name to farmOS.py.

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -1,4 +1,4 @@
-site_name: farmOS.py Docs
+source_name: farmOS.py
 nav:
   - Getting started: index.md
   - Authorization: authorization.md


### PR DESCRIPTION
Small change to the `docs/config.yml` to make it a little more consistent in the farmos.org navigation (farmOS/farmOS.org-EXPERIMENTAL#23).

There's some whitespace funkiness going on at the EOF, probably b/c I just did this in the GitHub editor. Seems there wasn't a newline at EOF previously. I didn't add one, but it's showing up in the diff for some reason. I can amend this if you prefer.